### PR TITLE
feat: 메인 페이지에 스피너 로딩 처리 추가

### DIFF
--- a/src/AppMain.jsx
+++ b/src/AppMain.jsx
@@ -6,6 +6,7 @@ import LinkCard from './components/LinkCard/LinkCard';
 import useInfiniteScroll from './hooks/useInfiniteScroll';
 import styles from './styles/AppMain.module.css';
 import SearchNull from './components/SearchNull/SearchNull';
+import { Spinner } from './components/spinner/Spinner';
 
 export default function AppMain() {
   // useState 훅을 사용하여 상태 관리
@@ -183,26 +184,31 @@ export default function AppMain() {
         <FilterModal orderBy={orderBy} setOrderBy={setOrderBy} setShowFilter={setShowFilter} />
       )}
 
-      {/* 메인 컨텐츠: 검색 전/후, 결과 유무에 따른 조건부 렌더링 */}
-      <main className={styles['main-container']}>
-        {!hasSearched ? (
-          // 검색 전: 전체 리스트
-          linkShoplist.map((shop) => <LinkCard key={shop.id} data={shop} />)
-        ) : linkShoplist.length > 0 ? (
-          // 검색 후 결과 있음
-          linkShoplist.map((shop) => <LinkCard key={shop.id} data={shop} />)
-        ) : (
-          // 검색 후 결과 없음
-          <div className={styles['search-null']}>
-            <SearchNull />
-          </div>
-        )}
+      {/* 로딩 중일 때 스피너 표시 */}
+      {isFetching && linkShoplist.length === 0 ? (
+        <Spinner />
+      ) : (
+        // {/* 메인 컨텐츠: 검색 전/후, 결과 유무에 따른 조건부 렌더링 */}
+        <main className={styles['main-container']}>
+          {!hasSearched ? (
+            // 검색 전: 전체 리스트
+            linkShoplist.map((shop) => <LinkCard key={shop.id} data={shop} />)
+          ) : linkShoplist.length > 0 ? (
+            // 검색 후 결과 있음
+            linkShoplist.map((shop) => <LinkCard key={shop.id} data={shop} />)
+          ) : (
+            // 검색 후 결과 없음
+            <div className={styles['search-null']}>
+              <SearchNull />
+            </div>
+          )}
 
-        {/* 무한스크롤 트리거 역할 */}
-        {/* hasNextPage가 true일때만 렌더링됨 (= 더 불러올 데이터가 있을때만) */}
-        {/* useInfiniteScroll 훅에서 fetchMoreShops(다음페이지요청) 실행됨 */}
-        {hasNextPage && <div ref={infiniteScrollRef} style={{ height: '20px' }} />}
-      </main>
+          {/* 무한스크롤 트리거 역할 */}
+          {/* hasNextPage가 true일때만 렌더링됨 (= 더 불러올 데이터가 있을때만) */}
+          {/* useInfiniteScroll 훅에서 fetchMoreShops(다음페이지요청) 실행됨 */}
+          {hasNextPage && <div ref={infiniteScrollRef} style={{ height: '20px' }} />}
+        </main>
+      )}
     </>
   );
 }


### PR DESCRIPTION

## ✨ 작업 요약

-  링크샵 데이터를 가져오는 동안 화면이 비어 보이지 않도록 Spinner 컴포넌트를 적용했습니다.

## 🔧 주요 변경 사항

- 조건: isFetching이 true이고, 데이터 배열이 비어 있을 때만 스피너가 표시됩니다.

## ✅ 체크리스트

- [x] 기능이 정상적으로 작동함
- [x] 스타일/UI 확인 완료
- [x] 충돌 없이 머지 가능한 상태임

## 💬 리뷰 시 참고할 점
![메인로딩스피너](https://github.com/user-attachments/assets/04834906-0f13-4a33-bdd2-f539fa574936)


- 확인해줬으면 하는 부분이나 설명이 필요한 부분이 있다면 작성해주세요.
