### PR TITLE
feat: 상점 상품이미지 없으면 기본 이미지로 설정

### DIFF
--- a/src/components/ProductList/ProductList.jsx
+++ b/src/components/ProductList/ProductList.jsx
@@ -3,6 +3,7 @@
 // 상품 이미지를 최대 3개까지만 보여줍니다.
 
 import styles from './ProductList.module.css';
+import ProductImage from '../productimage/ProductImage';
 
 const ProductList = ({ products }) => {
   const limited = products.slice(0, 3); // 최대 3개까지만 보여줌
@@ -10,7 +11,12 @@ const ProductList = ({ products }) => {
   return (
     <div className={styles.productList}>
       {limited.map((item) => (
-        <img key={item.id} src={item.imageUrl} alt={item.name} className={styles.productImage} />
+        <ProductImage
+          key={item.id}
+          imageUrl={item.imageUrl}
+          alt={item.name}
+          className={styles.productImage}
+        />
       ))}
     </div>
   );

--- a/src/components/ProductList/ProductList.module.css
+++ b/src/components/ProductList/ProductList.module.css
@@ -3,7 +3,6 @@
   display: flex;
   gap: 12px;
   overflow-x: auto;
-  margin-top: 8px;
 }
 
 .productImage {

--- a/src/components/productimage/ProductImage.jsx
+++ b/src/components/productimage/ProductImage.jsx
@@ -29,7 +29,7 @@ export default function ProductImage({ imageUrl, alt }) {
       alt={alt}
       width={95}
       height={95}
-      style={{ objectFit: 'cover' }}
+      style={{ objectFit: 'cover', borderRadius: 10 }}
       onError={() => setIsError(true)}
     />
   );


### PR DESCRIPTION

## ✨ 작업 요약
- 상품 이미지가 없거나 깨졌을 경우 `No Image` 기본 이미지로 표시되도록 설정
- `ProductImage` 컴포넌트를 `ProductList`에 적용하여 사용자 경험 개선

## 🔧 주요 변경 사항

- 이미지 없는 상점 카드에서도 기본 이미지가 잘 렌더링되는지 확인해주세요.

## ✅ 체크리스트

- [x] 기능이 정상적으로 작동함
- [x] 스타일/UI 확인 완료
- [x] 충돌 없이 머지 가능한 상태임

## 💬 리뷰 시 참고할 점

-
![image](https://github.com/user-attachments/assets/3e43b287-9175-4852-8509-178e07d72dc6)

