### PR TITLE
fix: 카드 상점프로필 에러시 기본이미지로 

### DIFF
--- a/src/AppMain.jsx
+++ b/src/AppMain.jsx
@@ -21,6 +21,7 @@ export default function AppMain() {
 
   const navigate = useNavigate();
 
+  //필터 모달에서 정렬 기준을 바꿨을 때 동작
   useEffect(() => {
     fetchInitialShops();
   }, [orderBy]);
@@ -82,7 +83,7 @@ export default function AppMain() {
   // keyword가 바뀔 때마다 호출되도록 설정
   const handleLinkShopList = async () => {
     const result = await getLinkShopList({ keyword });
-    setLinkShopList(result.list); // 이렇게 수정!!
+    setLinkShopList(result.list);
   };
 
   // 검색어가 바뀔 때마다 getLinkShopList 호출

--- a/src/components/LinkCard/LinkCard.jsx
+++ b/src/components/LinkCard/LinkCard.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 const LinkCard = React.forwardRef(({ data }, ref) => {
   const { name, userId, likes, products, shop, id } = data;
+  const [imgSrc, setImgSrc] = React.useState(shop.imageUrl);
 
   const navigate = useNavigate();
 
@@ -13,14 +14,20 @@ const LinkCard = React.forwardRef(({ data }, ref) => {
     navigate(`/link/${id}`);
   };
 
+  const handleStoreImageError = () => {
+    setImgSrc('/images/profile1.png'); //깨지면 기본이미지로
+  };
+
   return (
     <div className={styles.container} ref={ref} onClick={handleClick}>
       <div className={styles.header}>
         <img
-          src={shop.imageUrl !== 'https://example.com/...' ? shop.imageUrl : '/images/profile1.png'}
+          src={imgSrc}
           alt='store icon'
           className={styles.avatar}
+          onError={handleStoreImageError} // 이미지로드 실패시 기본이미지로 대체
         />
+
         <div>
           <h2 className={styles.storeName}>{name}</h2>
           <p className={styles.handle}>@{userId}</p>


### PR DESCRIPTION

## ✨ 작업 요약

- 에러처리:  기본이미지(red box)로 보일 수 있게 코드를 추가했습니다.

## 🔧 주요 변경 사항

- 이미지로드 실패시 기본이미지로 대체하도록 LinkCard.jsx 코드 수정완료

## ✅ 체크리스트

- [x] 기능이 정상적으로 작동함
- [x] 스타일/UI 확인 완료
- [x] 충돌 없이 머지 가능한 상태임

## 💬 리뷰 시 참고할 점
![image](https://github.com/user-attachments/assets/5a0a2c0c-c03b-40c2-abb0-7ad4aef39772)

- 확인해줬으면 하는 부분이나 설명이 필요한 부분이 있다면 작성해주세요.
